### PR TITLE
Bumped supported OrientDb version to 2.2.5. Added javax.persistence.a…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,10 @@ lazy val commonSettings = Seq(
     "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
   ),
 libraryDependencies ++= Seq(
+  "javax.persistence" % "persistence-api" % "1.0.2",
   "com.tinkerpop.blueprints" % "blueprints-core" % "2.6.0",
-  "com.orientechnologies" % "orientdb-core" % "2.1.8",
-  "com.orientechnologies" % "orientdb-graphdb" % "2.1.8",
+  "com.orientechnologies" % "orientdb-core" % "2.2.5",
+  "com.orientechnologies" % "orientdb-graphdb" % "2.2.5",
   "org.scala-lang" % "scalap" % "2.11.8", //TODO fix scala dep on scalaVersion
   //"jline" % "jline" % "2.12.1",
   "jline" % "jline" % "0.9.94",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.1")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 //addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")

--- a/src/main/scala/com/emotioncity/soriento/EnumReflector.scala
+++ b/src/main/scala/com/emotioncity/soriento/EnumReflector.scala
@@ -72,7 +72,7 @@ class EnumReflector(val enumElementType: Type) {
       .map { s =>
         val memberName = s.name.toString
         val enumValue = enumObject.getClass.getMethod(memberName).invoke(enumObject).asInstanceOf[scala.Enumeration$Value]
-        println(s"${memberName} ${enumValue}")
+//        println(s"${memberName} ${enumValue}")
         (memberName -> enumValue)
       }: _*
   )

--- a/src/main/scala/com/emotioncity/soriento/RichODatabaseDocumentImpl.scala
+++ b/src/main/scala/com/emotioncity/soriento/RichODatabaseDocumentImpl.scala
@@ -65,11 +65,11 @@ object RichODatabaseDocumentImpl {
       //println("ThreadLocal is: " + instance.getClass.getName)
       Future {
         val internalDb = if (isPooled) {
-          val tempDb = db.asInstanceOf[ODatabaseDocumentTx]
-          tempDb.activateOnCurrentThread()
+          db.asInstanceOf[ODatabaseDocumentTx]
         } else {
           instance.asInstanceOf[ODatabaseDocumentTx].copy()
         }
+        internalDb.activateOnCurrentThread()
         blocking {
           payload(internalDb)
         }


### PR DESCRIPTION
…i 1.0.2 to dependencies since it was deleted as orientDb dependency. Added sbt-dependency-graph plugin to analyze project dependency better. Fixed activation of database for threads when queries are async.
